### PR TITLE
Register tooltip with the new `TooltipDataProcessor`

### DIFF
--- a/ProgressTracker.lua
+++ b/ProgressTracker.lua
@@ -321,7 +321,7 @@ function Mod:Startup()
 	self:RegisterEvent("CHALLENGE_MODE_RESET")
 	self:RegisterAddOnLoaded("Blizzard_ObjectiveTracker")
 	CheckTime(GetWorldElapsedTimers())
-	GameTooltip:HookScript("OnTooltipSetUnit", OnTooltipSetUnit)
+	TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Unit, OnTooltipSetUnit)
 
 	Addon.Config:RegisterCallback('progressFormat', function()
 		local usedBars = SCENARIO_TRACKER_MODULE.usedProgressBars[ScenarioObjectiveBlock] or {}


### PR DESCRIPTION
Fixes https://github.com/Ermad/angry-keystones/issues/35

Replaces the old script handler that got removed in 10.0.2.