### PR TITLE
Add time limit to dungeon icon tooltip

### DIFF
--- a/Locale.lua
+++ b/Locale.lua
@@ -49,6 +49,7 @@ langs.enUS = {
 	config_schedule = "Display keystone schedule and party keystones (requires reload UI)",
 	["dungeon_Shadowmoon Burial Grounds"] = "Shadowmoon",
 	["dungeon_Temple of the Jade Serpent"] = "Jade Serpent",
+	timeLimit = "Time Limit %s",
 }
 langs.enGB = langs.enUS
 

--- a/Schedule.lua
+++ b/Schedule.lua
@@ -26,6 +26,7 @@ local currentWeek
 local currentKeystoneMapID
 local currentKeystoneLevel
 local unitKeystones = {}
+local hookedIconTooltips = false
 
 local function GetNameForKeystone(keystoneMapID, keystoneLevel)
 	local keystoneMapName = keystoneMapID and C_ChallengeMode.GetMapUIInfo(keystoneMapID)
@@ -142,6 +143,19 @@ local function UpdateFrame()
 		Mod.AffixFrame.Label:Show()
 	end
 	UpdatePartyKeystones()
+
+	if not hookedIconTooltips then
+		hookedIconTooltips = true
+		local timeLimitFormat = Addon.Locale:Get("timeLimit")
+		for _, icon in next, ChallengesFrame.DungeonIcons do
+			icon:HookScript("OnEnter", function(self)
+				local _, _, timeLimit = C_ChallengeMode.GetMapUIInfo(self.mapID)
+				GameTooltip_AddBlankLineToTooltip(GameTooltip)
+				GameTooltip_AddColoredLine(GameTooltip, timeLimitFormat:format(SecondsToClock(timeLimit)), HIGHLIGHT_FONT_COLOR)
+				GameTooltip:Show()
+			end)
+		end
+	end
 end
 
 local function makeAffix(parent)


### PR DESCRIPTION
Adds a row on the end showing the time limit of the dungeon.

![image](https://user-images.githubusercontent.com/1662735/215903560-bd5ffa52-ba8c-4296-8a0f-ccc4c0f55b39.png)
