### PR TITLE
Add support for Kaliels Tracker version 10.x+.

### DIFF
--- a/ObjectiveTracker.lua
+++ b/ObjectiveTracker.lua
@@ -127,8 +127,13 @@ local function ShowBlock(timerID, elapsedTime, timeLimit)
 	end
 end
 
-hooksecurefunc("Scenario_ChallengeMode_UpdateTime", UpdateTime)
-hooksecurefunc("Scenario_ChallengeMode_ShowBlock", ShowBlock)
+if IsAddOnLoaded("!KalielsTracker") then
+	hooksecurefunc("KT_Scenario_ChallengeMode_UpdateTime", UpdateTime)
+	hooksecurefunc("KT_Scenario_ChallengeMode_ShowBlock", ShowBlock)
+else
+	hooksecurefunc("Scenario_ChallengeMode_UpdateTime", UpdateTime)
+	hooksecurefunc("Scenario_ChallengeMode_ShowBlock", ShowBlock)
+end
 
 local keystoneWasCompleted = false
 function Mod:PLAYER_ENTERING_WORLD()


### PR DESCRIPTION
Kaliels Tracker for dragonflight to get around taint issues reimplements the default objective tracker renaming everything with a KT_ prefix. 