### PR TITLE
Add an icon for the addon

### DIFF
--- a/AngryKeystones.toc
+++ b/AngryKeystones.toc
@@ -6,6 +6,7 @@
 ## SavedVariablesPerCharacter: AngryKeystones_CharacterConfig
 ## OptionalDeps: !KalielsTracker
 ## X-Packaged-Version: @project-version@
+## IconTexture: Interface\Icons\inv_relics_hourglass
 ## Category-enUS: Dungeons & Raids
 ## Category-deDE: Dungeons & Schlachtzüge
 ## Category-esES: Mazmorras y bandas


### PR DESCRIPTION
Hi ! 

I've been using your addon for years but it's a bit sad to see that it doesn't have an icon :( 
I took the liberty of adding the basic icon of the keystone, but it could be literally any other WoW icon or even a custom one. 

For eg: 
- https://wow.zamimg.com/images/wow/icons/large/achievement_challengemode_scholomance_gold.jpg
- https://wow.zamimg.com/images/wow/icons/large/achievement_challengemode_scarletmonastery_hourglass.jpg
- https://wow.zamimg.com/images/wow/icons/large/achievement_challengemode_gold.jpg

Before:
![image](https://github.com/user-attachments/assets/401ee549-d019-41e3-a039-707b398eccb4)

After:
![image](https://github.com/user-attachments/assets/3253bb21-0317-4320-87e4-04019f349d1a)
